### PR TITLE
Run checks from a GitHub Action

### DIFF
--- a/.github/workflows/check_urls.yml
+++ b/.github/workflows/check_urls.yml
@@ -1,0 +1,27 @@
+name: Check URLs
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "*/30 * * * *"
+
+jobs:
+  check_urls:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - name: Install dependencies
+        run: pip install requests
+      - name: Check URLs
+        run: python ./check_urls.py
+      - name: Commit changes
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add .
+          if ! git diff --exit-code --quiet HEAD --; then
+            git commit -m "Update CSV at $(date +"%Y-%m-%d %H:%M:%S %Z")"
+            git push
+          fi

--- a/.github/workflows/check_urls.yml
+++ b/.github/workflows/check_urls.yml
@@ -13,9 +13,9 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
       - name: Install dependencies
-        run: pip install requests
+        run: pip install aiohttp
       - name: Check URLs
-        run: python ./check_urls.py
+        run: python -W ignore::DeprecationWarning ./check_urls.py
       - name: Commit changes
         run: |
           git config user.name github-actions

--- a/check_urls.py
+++ b/check_urls.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+
+import argparse
+import csv
+import datetime
+import logging
+import os
+import requests
+import sys
+
+from multiprocessing import Pool
+from pathlib import Path
+
+try:
+    assert sys.stdout.isatty()
+    from termcolor import colored
+except (AssertionError, ImportError):
+
+    def colored(text, *args, **kwargs):
+        """Dummy function to pass text through without escape codes if stdout is not a
+        TTY or termcolor is not available."""
+        return text
+
+
+URLS_PATH = Path("urls.txt")
+OUTPUT_PATH = Path("data.csv")
+
+
+def check(url):
+    logging.debug("Checking %s", url)
+    try:
+        _response = requests.get(url, timeout=30)
+        logging.info(colored("ok %s", "green"), url)
+        return
+    except Exception as e:
+        logging.info(colored("error: %s", "red"), url)
+        return {
+            "time": datetime.datetime.now().isoformat(),
+            "url": url,
+            "error": str(e),
+        }
+
+
+def check_urls(urls, output_stream):
+    # time that the run started
+    started = datetime.datetime.now().isoformat()
+
+    # start up processes to check the URLs
+    with Pool(len(os.sched_getaffinity(0))) as pool:
+        logging.info(colored("%s checking %d urls", "yellow"), started, len(urls))
+        for result in pool.map(check, urls):
+            if result:
+                result["run"] = started
+                output_stream.writerow({"run": started, **result})
+
+
+def main():
+
+    parser = argparse.ArgumentParser(description="Description: {}".format(__file__))
+
+    parser.add_argument(
+        "-v", "--verbose", action="store_true", default=False, help="Increase verbosity"
+    )
+    parser.add_argument(
+        "-q", "--quiet", action="store_true", default=False, help="Quiet operation"
+    )
+
+    args = parser.parse_args()
+
+    log_level = logging.DEBUG if args.verbose else logging.INFO
+    log_level = logging.CRITICAL if args.quiet else log_level
+    logging.basicConfig(level=log_level, format="%(message)s")
+
+    with URLS_PATH.open("r", encoding="utf8") as _fh:
+        urls = [_.strip() for _ in _fh.readlines()]
+
+    with OUTPUT_PATH.open("a", encoding="utf8") as _fh:
+        writer = csv.DictWriter(_fh, fieldnames=["run", "time", "url", "error"])
+        if not _fh.tell():
+            writer.writeheader()
+        check_urls(urls, writer)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ jupyterlab
 ipyleavelet
 python-geoip-python3
 python-geoip-geolite2
+aiohttp


### PR DESCRIPTION
This PR adds a new script (based only loosely at this point on `monitor.py`) and a GitHub Actions workflow to run the script every 30 minutes, append the results to `data.csv` and commit the changes back to the repo.

One thing to note: if/when merged, the action will run at 1 and 31 minutes past the hour (or when the workflow is triggered manually), and it takes about 15 minutes to complete (although there are some uncontrollables about all of these numbers).  The attempt to commit new results to the CSV file will fail if the repo is modified while the action is running (the workflow can be made somewhat robust to this if needs be).